### PR TITLE
build(deps): bump moment from 2.24.0 to 2.25.3 (#6530)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,9 +57,6 @@
     "last 2 versions",
     "not ie <= 10"
   ],
-  "resolutions": {
-    "moment": "2.24.0"
-  },
   "dependencies": {
     "@ant-design/icons": "^4.0.0",
     "@ant-design/pro-layout": "^5.0.8",
@@ -67,7 +64,7 @@
     "antd": "4.2.0",
     "classnames": "^2.2.6",
     "lodash": "^4.17.11",
-    "moment": "~2.24.0",
+    "moment": "^2.25.3",
     "omit.js": "^1.0.2",
     "path-to-regexp": "2.4.0",
     "qs": "^6.9.0",


### PR DESCRIPTION
* build(deps): bump moment from 2.24.0 to 2.25.3

Bumps [moment](https://github.com/moment/moment) from 2.24.0 to 2.25.3.
- [Release notes](https://github.com/moment/moment/releases)
- [Changelog](https://github.com/moment/moment/blob/develop/CHANGELOG.md)
- [Commits](https://github.com/moment/moment/commits)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

* remove resolutions for moment

Co-authored-by: dependabot-preview[bot] <27856297+dependabot-preview[bot]@users.noreply.github.com>
Co-authored-by: chenshuai2144 <qixian.cs@outlook.com>